### PR TITLE
fix: distribute as normal lib (not shaded)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-core</artifactId>
-      <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.11.5</version>
-    </dependency>
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
       <version>2.25.56</version>


### PR DESCRIPTION
Removes any unnecessary dependencies since we're no longer going to be distributing as a fat-jar. 
